### PR TITLE
Update jquery.signaturepad.js

### DIFF
--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -396,7 +396,7 @@ function SignaturePad (selector, options) {
     eventsBound = true
 
     // Closes open keyboards to free up space
-    $('input').blur();
+    $('input:focus').blur();
 
     if (typeof e.targetTouches !== 'undefined')
       touchable = true

--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -396,8 +396,10 @@ function SignaturePad (selector, options) {
     eventsBound = true
 
     // Closes open keyboards to free up space
-    $('input:focus').blur();
-
+    if( document.activeElement && document.activeElement.nodeName === "INPUT"){
+      $( document.activeElement ).blur();
+    }
+    
     if (typeof e.targetTouches !== 'undefined')
       touchable = true
 


### PR DESCRIPTION
Making binding of blur event more specific. With this change blur event will be triggered only when signature pad is in focus. Without this change blur event is fired even if focus is not on signature canvas. Binding on just "input" element is too generic which can easily get in conflict with other "input" elements present in the web page.

Please review the changes
